### PR TITLE
delete column email from Patients model

### DIFF
--- a/api/src/models/Patient.ts
+++ b/api/src/models/Patient.ts
@@ -8,9 +8,6 @@ export class Patient extends Model {//<Patient>
 	lastName!: string;
 
 	@Column
-	email!: string;
-
-	@Column
 	phone!: number;
 
 	@Column


### PR DESCRIPTION
The field was written in red because we should delete it. It is because the email field already exists in the Users table.