### PR TITLE
Fix/clean select a medic when initialize

### DIFF
--- a/client/src/components/Home/Appointments/CardSpec.module.css
+++ b/client/src/components/Home/Appointments/CardSpec.module.css
@@ -1,9 +1,8 @@
 .cardContainer {
-  width: 25%;
   height: auto;
   background-color: #fff;
   border-radius: 1rem;
-  padding: 1.2rem 2.5rem;
+  padding: 1.2rem 2rem;
   margin: 1rem 0.5rem;
   transition: background-color 0.5s;
 }

--- a/client/src/components/Home/Appointments/CardSpec.tsx
+++ b/client/src/components/Home/Appointments/CardSpec.tsx
@@ -31,10 +31,10 @@ export const Card = ({ date, hours, medicInfo }: CardProps): JSX.Element => {
       const response = await axios.post("http://localhost:3001/appointments", {
         date: date,
         time: selected.hour,
-        patientId: userActive.UserId,
+        patientId: userActive.id,
         medicalStaffId: medicInfo.MedicalStaffId,
       });
-      dispatch(getAppointments(userActive.UserId));
+      dispatch(getAppointments(userActive.id));
       history.push("/home/appointments");
     } catch (error) {
       console.log(error);

--- a/client/src/components/Home/Appointments/NewAppointment.module.css
+++ b/client/src/components/Home/Appointments/NewAppointment.module.css
@@ -101,6 +101,5 @@
 
 .cardSpecContainer{
   display: flex;
-  /* grid-template-columns: 25% 25% 25% 25%;  
-  grid-gap: 5px !important; */
+  flex-wrap: wrap;
 }

--- a/client/src/components/Home/Appointments/NewAppointment.tsx
+++ b/client/src/components/Home/Appointments/NewAppointment.tsx
@@ -72,7 +72,7 @@ const NewAppointment: FunctionComponent = () => {
                 </select>
                 <select id="medic"name="medic" onChange={handleChangeAvailable}>
                   <option  value="selectMedic">Select a medic</option>
-                  {medics.length && <option value="all">All</option>}
+                  {(medics.length && medics.length > 1) && <option value="all">All</option>}
                   {medics.length &&
                     medics.map((medic: any) => {
                       return (

--- a/client/src/reducers/index.ts
+++ b/client/src/reducers/index.ts
@@ -44,6 +44,7 @@ export default function reducer(state = initialState, action: actionI) {
       return {
         ...state,
         specialities: action.payload,
+        medicSpeciality: []
       };
     case ActionTypes.getMedicSpeciality:
       return {


### PR DESCRIPTION
El select que desplega los medicos por especialidad quedaba cargado con los medicos de la busqueda anterior. Ahora limpia el select tambien cuando se recarga la pagina 